### PR TITLE
Prevent named trait metadata from being duplicated as generic metadata

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,8 @@ GEM
     faraday (0.17.3)
       multipart-post (>= 1.2, < 3)
     ffi (1.12.2)
+    get_process_mem (0.2.5)
+      ffi (~> 1.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     haml (5.1.2)
@@ -322,6 +324,9 @@ GEM
     unicorn (5.5.3)
       kgio (~> 2.6)
       raindrops (~> 0.7)
+    unicorn-worker-killer (0.4.4)
+      get_process_mem (~> 0)
+      unicorn (>= 4, < 6)
     warden (1.2.8)
       rack (>= 2.0.6)
     web-console (3.7.0)
@@ -381,6 +386,7 @@ DEPENDENCIES
   uglifier
   unicode-emoji
   unicorn
+  unicorn-worker-killer
   web-console
   whenever
 

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -1,6 +1,13 @@
 # Publish to the website database as quick as you can, please. NOTE: We will NOT publish Terms in this code.
+require "set"
+
 class Publisher
   attr_accessor :resource
+
+  IGNORE_OCCURRENCE_METADATA_PRED_URIS = Set.new([
+    "http://rs.tdwg.org/dwc/terms/lifeStage",
+    "http://rs.tdwg.org/dwc/terms/sex"
+  ])
 
   def self.by_resource(resource_in, process, options = {})
     new(options.merge(resource: resource_in, process: process)).by_resource
@@ -543,6 +550,8 @@ class Publisher
       body += " <a href='#{meta.url}'>link</a>" unless meta.url.blank?
       body += " #{meta.doi}" unless meta.doi.blank?
       literal = body
+    elsif meta.is_a?(OccurrenceMetadatum) && IGNORE_OCCURRENCE_METADATA_PRED_URIS.include?(meta.predicate_term&.uri)
+      return nil # these are written as fields in the traits file, so skip
     elsif (meta_mapping = moved_meta[meta.predicate_term&.uri])
       value = meta.literal
       value = meta.measurement if meta_mapping[:from] && meta_mapping[:from] == :measurement

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -4,7 +4,7 @@ require "set"
 class Publisher
   attr_accessor :resource
 
-  IGNORE_OCCURRENCE_METADATA_PRED_URIS = Set.new([
+  SKIP_METADATA_PRED_URIS = Set.new([
     "http://rs.tdwg.org/dwc/terms/lifeStage",
     "http://rs.tdwg.org/dwc/terms/sex"
   ])
@@ -550,8 +550,8 @@ class Publisher
       body += " <a href='#{meta.url}'>link</a>" unless meta.url.blank?
       body += " #{meta.doi}" unless meta.doi.blank?
       literal = body
-    elsif meta.is_a?(OccurrenceMetadatum) && IGNORE_OCCURRENCE_METADATA_PRED_URIS.include?(meta.predicate_term&.uri)
-      return nil # these are written as fields in the traits file, so skip
+    elsif SKIP_METADATA_PRED_URIS.include?(meta.predicate_term&.uri)
+      return nil # these are written as fields in the traits file, so skip (associations are populated from OccurrenceMetadata in ResourceHarvester#resolve_trait_keys)
     elsif (meta_mapping = moved_meta[meta.predicate_term&.uri])
       value = meta.literal
       value = meta.measurement if meta_mapping[:from] && meta_mapping[:from] == :measurement

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -34,10 +34,11 @@ class Resource < ApplicationRecord
       Rails.cache.fetch('resources/harvested_dynamic_hierarchy_1_1') do
         Resource.where(abbr: 'dvdtg').first_or_create do |r|
           r.name = 'EOL Dynamic Hierarchy 1.1'
-          r.partner = nil#Partner.native
+          r.partner = nil
           r.description = ''
           r.abbr = 'dvdtg'
           r.is_browsable = true
+          r.might_have_duplicate_taxa = false
           r.nodes_count = 650000
         end
       end

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -34,11 +34,10 @@ class Resource < ApplicationRecord
       Rails.cache.fetch('resources/harvested_dynamic_hierarchy_1_1') do
         Resource.where(abbr: 'dvdtg').first_or_create do |r|
           r.name = 'EOL Dynamic Hierarchy 1.1'
-          r.partner = Partner.native
+          r.partner = nil#Partner.native
           r.description = ''
           r.abbr = 'dvdtg'
           r.is_browsable = true
-          r.has_duplicate_nodes = false
           r.nodes_count = 650000
         end
       end

--- a/app/models/store/traits.rb
+++ b/app/models/store/traits.rb
@@ -53,22 +53,16 @@ module Store
 
     def to_traits_units(_, val)
       @models[:trait] ||= {}
-      @models[:trait][:meta] ||= {}
-      @models[:trait][:meta]['http://rs.tdwg.org/dwc/terms/measurementUnit'] = val
       @models[:trait][:units] = val
     end
 
     def to_traits_statistical_method(_, val)
       @models[:trait] ||= {}
-      @models[:trait][:meta] ||= {}
-      @models[:trait][:meta]['http://eol.org/schema/terms/statisticalMethod'] = val
       @models[:trait][:statistical_method] = val
     end
 
     def to_traits_source(_, val)
       @models[:trait] ||= {}
-      @models[:trait][:meta] ||= {}
-      @models[:trait][:meta]['http://purl.org/dc/terms/source'] = val
       @models[:trait][:source] = val
     end
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -8,7 +8,7 @@ common: &common
 default: &default
   <<: *common
   username: root
-  password:
+  password: <%= Rails.application.secrets.db[:password] || "" %>
   socket: /tmp/mysql.sock
 
 development:


### PR DESCRIPTION
- only publish units, sex, lifestage, statistical method and source to traits file
- fix "traits with metadata nodes that carry units also inherit those units" issue reported by Jen