### PR TITLE
always add unmodified_url (with host) to published media

### DIFF
--- a/app/models/medium.rb
+++ b/app/models/medium.rb
@@ -79,6 +79,24 @@ class Medium < ApplicationRecord
     "#{path}/#{basename}"
   end
 
+  def default_unmodified_url
+    "#{default_base_url}.#{file_ext}"
+  end
+
+  def embedded_video?
+    youtube? || vimeo?
+  end
+
+  def file_ext
+    if js_map? || embedded_video?
+      nil
+    elsif video? && ogg?
+      'ogv'
+    else
+      format
+    end
+  end
+
   def basename
     "#{resource_id}.#{resource_pk&.tr('^-_A-Za-z0-9', '_')}"
   end

--- a/app/models/medium_prepper/resizable_image.rb
+++ b/app/models/medium_prepper/resizable_image.rb
@@ -13,7 +13,7 @@ module MediumPrepper
       # NOTE: you can try changing this to make for faster downloads (smaller values, down to 10) or better
       # representation of the original (higher values, up to 100)
       @our_quality = 60
-      @ext = 'jpg'
+      @ext = medium.file_ext
       read_image(raw)
     end
 

--- a/app/models/medium_prepper/save_and_serve.rb
+++ b/app/models/medium_prepper/save_and_serve.rb
@@ -5,24 +5,13 @@ module MediumPrepper
     def initialize(medium, raw)
       @downloaded_at = Time.now
       @medium = medium
-      get_ext(raw.base_uri)
+      get_ext
       save_ogg(raw)
     end
 
-    def get_ext(base_uri)
-      @ext = begin
-               File.extname(base_uri.path).downcase.gsub(/^\./, '')
-             rescue => e
-               raise "Unable to parse #{base_uri} for ext (#{e.class}: #{e.message})"
-             end
-      valid_exts = %w[mp3 ogg wav mp4 ogv mov svg webm]
-      return if valid_exts.include?(@ext)
-      # Well, shoot, we ended up with a file but it came from a funny-lookin URL. We'll skip the guessing and use the
-      # format, if we have one:
-      raise "Cannot determine a valid format for #{base_uri} (got #{@ext})" if @medium.format.nil?
-      # Really, we probably won't save and serve these anyway (we'll more likely embed them remotely):
-      raise "Don't know the ext used for #{@medium.format}!" if @medium.youtube? || @medium.flash? || @medium.vimeo?
-      @ext = @medium.format
+    def get_ext
+      @ext = @medium.video_file_ext
+      raise TypeError, "failed to get ext for Medium (#{@medium.id}, #{@medium.subclass}, #{@medium.format}" if @ext.nil?
     end
 
     def prep_medium

--- a/app/models/medium_prepper/save_and_serve.rb
+++ b/app/models/medium_prepper/save_and_serve.rb
@@ -10,7 +10,7 @@ module MediumPrepper
     end
 
     def get_ext
-      @ext = @medium.video_file_ext
+      @ext = @medium.file_ext
       raise TypeError, "failed to get ext for Medium (#{@medium.id}, #{@medium.subclass}, #{@medium.format}" if @ext.nil?
     end
 

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -435,12 +435,8 @@ class Publisher
     web_medium.resource_id = @web_resource_id
     web_medium.name = clean_values(medium.name_verbatim) if medium.name.blank?
     web_medium.description = clean_values(medium.description_verbatim) if medium.description.blank?
-    web_medium.base_url = if medium.base_url.nil? # The image has not been downloaded.
-                            "#{@root_url}/#{medium.default_base_url}"
-                          else
-                            # It *has* been downloaded, but still lacks the root URL, so we add that:
-                            "#{@root_url}/#{medium.base_url}"
-                          end
+    web_medium.base_url = fixed_medium_url(medium, 'base')
+    web_medium.unmodified_url = fixed_medium_url(medium, 'unmodified') 
     web_medium.license_id = WebDb.license(medium.license&.source_url, @process)
     web_medium.language_id = WebDb.language(medium.language, @process)
     web_medium
@@ -695,5 +691,19 @@ class Publisher
       end
     end
     @files[file] = true
+  end
+
+  private
+
+  def fixed_medium_url(medium, type)
+    url_method_name = "#{type}_url"
+    default_url_method_name = "default_#{type}_url"
+
+    if medium.base_url.nil? # The image has not been downloaded.
+      "#{@root_url}/#{medium.send(default_url_method_name)}"
+    else
+      # It *has* been downloaded, but still lacks the root URL, so we add that:
+      "#{@root_url}/#{medium.send(url_method_name)}"
+    end
   end
 end


### PR DESCRIPTION
This branch addresses the following issue with videos: format can differ from extension (e.g., in the case of video/ogg and .ogv or .ogg), which makes it impossible for the publishing layer to infer which extension it should tack on to the base_url to construct the full file url. This change adds the already supported unmodified_url -- with host, which is currently missing  -- to all media following the pattern used for base_url. I'm making the assumption that formats should be considered as the second half of the media type (MIME type) for a Medium, which effectively makes formats like :ogv obsolete. 

This was the most minimally invasive change I could come up with to achieve the desired result. A more invasive, but perhaps more robust, approach would be to redesign the way we represent Media formats. What the publishing layer needs to display media differs by subclass (video, audio, etc.) but the superset of required fields is:

-  Media type (MIME type) for videos, e.g., video/ogg
-  Base url (w/o file extension)
- File extension, which should be decoupled from media type and therefore be a separate field

The 'unmodified' url isn't needed if the extension and base url are correct, since it's simply a concatenation of those. 

I'm happy with this change as 'good enough' for now, but I wanted to outline the more invasive option as well since I think it is a cleaner solution in the long term.